### PR TITLE
Add chatbot analysis and clause control

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,73 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import openai
+
+ORIENTATION_PATH = Path(__file__).with_name("orientacao.txt")
+
+
+def _load_orientation() -> str:
+    try:
+        with open(ORIENTATION_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+ORIENTATION_TEXT = _load_orientation()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def answer_question(question: str) -> str:
+    """Return an answer to the question using the orientation text."""
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Responda em português utilizando o texto de orientação a seguir como"
+                " referência:\n" + ORIENTATION_TEXT
+            ),
+        },
+        {"role": "user", "content": question},
+    ]
+    response = openai.ChatCompletion.create(
+        model="gpt-4o-mini",
+        messages=messages,
+        temperature=0,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def analyze_answers(answers: Dict[str, str]) -> Tuple[List[str], List[str], List[str]]:
+    """Analyze form answers and suggest clause markers to keep or remove."""
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Você é um assistente que avalia respostas de um formulário para gerar"
+                " um Termo de Referência. Utilize o texto de orientação abaixo para"
+                " embasar suas decisões. Retorne um JSON com as chaves 'manter',"
+                " 'excluir' e 'sugestoes'.\n" + ORIENTATION_TEXT
+            ),
+        },
+        {
+            "role": "user",
+            "content": "Respostas do usuário:\n" + json.dumps(answers, ensure_ascii=False, indent=2),
+        },
+    ]
+    response = openai.ChatCompletion.create(
+        model="gpt-4.1-mini",
+        messages=messages,
+        temperature=0,
+    )
+    content = response.choices[0].message.content
+    try:
+        data = json.loads(content)
+        keep = data.get("manter", [])
+        remove = data.get("excluir", [])
+        suggestions = data.get("sugestoes", [])
+    except Exception:
+        keep, remove, suggestions = [], [], [content]
+    return keep, remove, suggestions

--- a/orientacao.txt
+++ b/orientacao.txt
@@ -1,0 +1,4 @@
+Este documento contém orientações sobre a elaboração do Termo de Referência.
+Use o texto para responder dúvidas dos usuários e para avaliar as respostas
+coletadas no formulário. As cláusulas condicionais são marcadas com a sintaxe
+[[IF_NOME]] e [[END_IF_NOME]].

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-docx>=1.0
 docxtpl>=0.16
 docx2pdf>=0.1.8
 pydantic>=2.7
+openai>=1.14


### PR DESCRIPTION
## Summary
- add `chatbot.py` with functions for GPT-4 based Q&A and answer analysis
- include short orientation file
- support openai dependency
- extend Streamlit UI with chat interface and suggestions
- allow render logic to force keep/remove markers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a595da2cc832abeca5b794cfa94e0